### PR TITLE
Fixes AttributeError when using process workers with mp start method 'spawn'

### DIFF
--- a/pypeln/process/queue.py
+++ b/pypeln/process/queue.py
@@ -112,6 +112,13 @@ class IterableQueue(Queue, tp.Generic[T], tp.Iterable[T]):
 
         return PipelineException(exception_type, trace)
 
+    def __getstate__(self):
+        return super().__getstate__() + (self.namespace, self.exception_queue)
+
+    def __setstate__(self, state):
+        super().__setstate__(state[:-2])
+        self.namespace, self.exception_queue = state[-2:]
+
 
 class OutputQueues(tp.List[IterableQueue[T]], tp.Generic[T]):
     def put(self, x: T):


### PR DESCRIPTION
When using process workers with with mp start method 'spawn' (e.g. on Windows and macOS) one will run into the following error:

```
AttributeError: 'IterableQueue' object has no attribute 'namespace'
```

This happens because unlike 'fork', 'spawn' pickles IterableQueue objects and sends them to the child process. Thereby namespace and exception_queue attributes are lost, since they are not exported/restored by \_\_getstate\_\_ and \_\_setstate\_\_ methods.

This PR fixes this issue.

