### PR TITLE
fix: sync::from_iterable

### DIFF
--- a/pypeln/sync/api/from_iterable.py
+++ b/pypeln/sync/api/from_iterable.py
@@ -3,8 +3,7 @@ import typing as tp
 from pypeln import utils as pypeln_utils
 from pypeln.utils import T
 
-from ..stage import Stage, ProcessFn
-from dataclasses import dataclass
+from ..stage import Stage
 
 
 class FromIterable(tp.NamedTuple):

--- a/pypeln/sync/api/from_iterable.py
+++ b/pypeln/sync/api/from_iterable.py
@@ -7,8 +7,7 @@ from ..stage import Stage, ProcessFn
 from dataclasses import dataclass
 
 
-@dataclass
-class FromIterable(ProcessFn):
+class FromIterable(tp.NamedTuple):
     iterable: tp.Iterable
     maxsize: int
 


### PR DESCRIPTION
 TypeError: FromIterable() takes no arguments

Fixes: https://github.com/cgarciae/pypeln/issues/93